### PR TITLE
Reduce bundle size by requiring specific icons from fa

### DIFF
--- a/src/Banner.tsx
+++ b/src/Banner.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { Navbar, Nav, NavItem } from "react-bootstrap";
+
+import Navbar from "react-bootstrap/lib/Navbar";
+import Nav from "react-bootstrap/lib/Nav";
+import NavItem from "react-bootstrap/lib/NavItem";
 
 export class Banner extends React.Component<{ user: string, authenticated: boolean, logout: (event: any) => void }> {
     constructor(props: { user: string, authenticated: boolean, logout: (event: any) => void }) {

--- a/src/CreateAccount.tsx
+++ b/src/CreateAccount.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Database } from "./Database";
 import { Redirect } from "react-router-dom";
-import { Panel, Button } from "react-bootstrap";
 
+import Panel from "react-bootstrap/lib/Panel";
+import Button from "react-bootstrap/lib/Button";
 
 export class CreateAccount extends React.Component<{ authenticate: (user: string) => void }, { error: boolean, username: string, password: string, household: string, authenticated: boolean }> {
     constructor(props: { authenticate: () => void }) {

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { Database } from "./Database";
 import { Redirect } from "react-router-dom";
-import { Panel, Button } from "react-bootstrap";
 
+import Panel from "react-bootstrap/lib/Panel";
+import Button from "react-bootstrap/lib/Button";
 
 export class Login extends React.Component<{ authenticate: (user: string) => void }, { error: boolean, username: string, password: string, authenticated: boolean }> {
     constructor(props: { authenticate: () => void }) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,4 @@
 import { Ingredient } from "../models/ingredient";
-import { ajax } from "jquery";
 
 export function fuzzyCompare(str1: string, str2: string, fuzz: string) {
     return str1 === str2 || str1 === str2 + fuzz || str1 + fuzz === str2;
@@ -9,14 +8,6 @@ export function compareIngredients(a: Ingredient, b: Ingredient): boolean {
     let str1 = a.name.replace(' ', '').toLowerCase();
     let str2 = b.name.replace(' ', '').toLowerCase();
     return fuzzyCompare(str1, str2, 's') || fuzzyCompare(str1, str2, 'es') || fuzzyCompare(str1, str2, 'cooked');
-}
-
-export function simpleAjaxCall<T>(url: string): Promise<T> {
-    return ajax({
-        url,
-        method: 'GET',
-        context: document.body
-    }) as any;
 }
 
 // Array.prototype.contains = function (v) {

--- a/src/views/ingredienteditview.tsx
+++ b/src/views/ingredienteditview.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { Row, Col, FormGroup, Button } from "react-bootstrap";
+
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import FormGroup from "react-bootstrap/lib/FormGroup";
+import Button from "react-bootstrap/lib/Button";
+
 import { IIngredientRepo } from "../FoodApp";
 import { Ingredient } from "../models/ingredient";
 

--- a/src/views/inventoryview.tsx
+++ b/src/views/inventoryview.tsx
@@ -1,7 +1,17 @@
 // tslint:disable:no-console
 import * as React from "react";
+
 import { Container } from "react-bootstrap/lib/Tab";
-import { Grid, Row, Col, Panel, Modal, Button, Popover, OverlayTrigger, MenuItem, Clearfix } from "react-bootstrap";
+import Grid from "react-bootstrap/lib/Grid";
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import Panel from "react-bootstrap/lib/Panel";
+import Modal from "react-bootstrap/lib/Modal";
+import Button from "react-bootstrap/lib/Button";
+import Popover from "react-bootstrap/lib/Popover";
+import OverlayTrigger from "react-bootstrap/lib/OverlayTrigger";
+import MenuItem from "react-bootstrap/lib/MenuItem";
+import Clearfix from "react-bootstrap/lib/Clearfix";
 
 import FaPlus from "react-icons/lib/fa/plus";
 import FaTrash from "react-icons/lib/fa/trash";

--- a/src/views/inventoryview.tsx
+++ b/src/views/inventoryview.tsx
@@ -2,8 +2,15 @@
 import * as React from "react";
 import { Container } from "react-bootstrap/lib/Tab";
 import { Grid, Row, Col, Panel, Modal, Button, Popover, OverlayTrigger, MenuItem, Clearfix } from "react-bootstrap";
-import { FaPlus, FaTrash, FaEllipsisV, FaShoppingCart, FaFolder, FaPencil, FaSearch } from "react-icons/lib/fa"
-// FaTrash, FaPencil,
+
+import FaPlus from "react-icons/lib/fa/plus";
+import FaTrash from "react-icons/lib/fa/trash";
+import FaEllipsisV from "react-icons/lib/fa/ellipsis-v";
+import FaShoppingCart from "react-icons/lib/fa/shopping-cart";
+import FaFolder from "react-icons/lib/fa/folder";
+import FaPencil from "react-icons/lib/fa/pencil";
+import FaSearch from "react-icons/lib/fa/search";
+
 import { IIngredientRepo, IRecipeRepo } from "../FoodApp";
 import { Ingredient } from "../models/ingredient";
 import { IngredientEditView } from "./ingredienteditview";

--- a/src/views/photoeditview.tsx
+++ b/src/views/photoeditview.tsx
@@ -3,7 +3,11 @@ import { Row, Col, FormGroup, Button } from "react-bootstrap";
 import { Image } from "../models/image";
 import { Rotation } from "../models/rotation";
 import { IPhotoRepo } from "./photosapp";
-import { FaRotateLeft, FaRepeat, FaClose, FaArrowsH } from "react-icons/lib/fa";
+
+import FaRotateLeft from "react-icons/lib/fa/rotate-left";
+import FaRepeat from "react-icons/lib/fa/repeat";
+import FaClose from "react-icons/lib/fa/close";
+import FaArrowsH from "react-icons/lib/fa/arrows-h";
 
 export class PhotoEditView extends React.Component<{ photo: Image, repo: IPhotoRepo, onSave: () => void }, { photo: Image }> {
     constructor(props: { photo: Image, repo: IPhotoRepo, onSave: () => void }) {

--- a/src/views/photoeditview.tsx
+++ b/src/views/photoeditview.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { Row, Col, FormGroup, Button } from "react-bootstrap";
+
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import FormGroup from "react-bootstrap/lib/FormGroup";
+import Button from "react-bootstrap/lib/Button";
+
 import { Image } from "../models/image";
 import { Rotation } from "../models/rotation";
 import { IPhotoRepo } from "./photosapp";

--- a/src/views/photosapp.tsx
+++ b/src/views/photosapp.tsx
@@ -1,5 +1,9 @@
 import * as React from "react";
-import { Navbar, NavItem, Nav } from "react-bootstrap";
+
+import Navbar from "react-bootstrap/lib/Navbar";
+import NavItem from "react-bootstrap/lib/NavItem";
+import Nav from "react-bootstrap/lib/Nav";
+
 import { Route, Switch } from "react-router-dom";
 import { PhotoViewer } from "./photoviewer";
 import { PhotoManager } from "./photomanager";

--- a/src/views/photoviewer.tsx
+++ b/src/views/photoviewer.tsx
@@ -3,7 +3,12 @@ import { Image } from "../models/image";
 import { Modal, Row, Col, Button } from "react-bootstrap";
 import { PhotoEditView } from "./photoeditview";
 import { IPhotoRepo } from "./photosapp";
-import { FaPlus, FaCaretLeft, FaCaretRight, FaPaintBrush } from "react-icons/lib/fa";
+
+import FaPlus from "react-icons/lib/fa/plus";
+import FaCaretLeft from "react-icons/lib/fa/caret-left";
+import FaCaretRight from "react-icons/lib/fa/caret-right";
+import FaPaintBrush from "react-icons/lib/fa/paint-brush";
+
 import { Rotation } from "../models/rotation";
 
 export class PhotoViewer extends React.Component<{ repo: IPhotoRepo }, { selectedImage: Image | null, mode: string, editImage: Image }> {

--- a/src/views/photoviewer.tsx
+++ b/src/views/photoviewer.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { Image } from "../models/image";
-import { Modal, Row, Col, Button } from "react-bootstrap";
+
+import Modal from "react-bootstrap/lib/Modal";
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import Button from "react-bootstrap/lib/Button";
+
 import { PhotoEditView } from "./photoeditview";
 import { IPhotoRepo } from "./photosapp";
 

--- a/src/views/recipeeditview.tsx
+++ b/src/views/recipeeditview.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { Row, Col, FormGroup, Button } from "react-bootstrap";
+
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import FormGroup from "react-bootstrap/lib/FormGroup";
+import Button from "react-bootstrap/lib/Button";
+
 import { Recipe } from "../models/recipe";
 import { IRecipeRepo } from "../FoodApp";
 import { Material } from "../models/material";

--- a/src/views/recipeeditview.tsx
+++ b/src/views/recipeeditview.tsx
@@ -3,7 +3,10 @@ import { Row, Col, FormGroup, Button } from "react-bootstrap";
 import { Recipe } from "../models/recipe";
 import { IRecipeRepo } from "../FoodApp";
 import { Material } from "../models/material";
-import { FaMinusCircle, FaPlus } from "react-icons/lib/fa"
+
+import FaMinusCircle from "react-icons/lib/fa/minus-circle";
+import FaPlus from "react-icons/lib/fa/plus";
+
 import { Ingredient } from "../models/ingredient";
 
 export class RecipeEditView extends React.Component<{ recipe: Recipe, repo: IRecipeRepo, onSave: () => void }, { recipe: Recipe }> {

--- a/src/views/recipesview.tsx
+++ b/src/views/recipesview.tsx
@@ -5,7 +5,13 @@ import { Grid, Row, Col, Panel, Modal, Button } from "react-bootstrap";
 import { Recipe } from "../models/recipe";
 import { Material } from "../models/material";
 import { RecipeEditView } from "./recipeeditview";
-import { FaTimesCircle, FaPencil, FaPlus, FaSearch, FaShoppingCart } from "react-icons/lib/fa"
+
+import FaTimesCircle from "react-icons/lib/fa/times-circle";
+import FaPencil from "react-icons/lib/fa/pencil";
+import FaPlus from "react-icons/lib/fa/plus";
+import FaSearch from "react-icons/lib/fa/search";
+import FaShoppingCart from "react-icons/lib/fa/shopping-cart";
+
 import { IRecipeRepo, IIngredientRepo } from "../FoodApp";
 import { Ingredient } from "../models/ingredient";
 import { compareIngredients } from "../utils/utils";

--- a/src/views/recipesview.tsx
+++ b/src/views/recipesview.tsx
@@ -1,7 +1,14 @@
 // tslint:disable:no-console
 import * as React from "react";
 import { Container } from "react-bootstrap/lib/Tab";
-import { Grid, Row, Col, Panel, Modal, Button } from "react-bootstrap";
+
+import Grid from "react-bootstrap/lib/Grid";
+import Row from "react-bootstrap/lib/Row";
+import Col from "react-bootstrap/lib/Col";
+import Panel from "react-bootstrap/lib/Panel";
+import Modal from "react-bootstrap/lib/Modal";
+import Button from "react-bootstrap/lib/Button";
+
 import { Recipe } from "../models/recipe";
 import { Material } from "../models/material";
 import { RecipeEditView } from "./recipeeditview";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
For some reason, react-icons doesn't seem to use es6 modules like it should and instead uses commonjs modules. Tree shaking only works with es6 modules, so importing `"react-icons/lib/fa"` will get you a big pile of embedded SVG that adds a ton of size.

This change reduces the bundle size from 1.1 MB to 505 KB.