### PR TITLE
Redirect http to https connections in prod

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -48,6 +48,13 @@ if (process.env.NODE_ENV === 'production' || testProd) {
   app.use(express.static('build'));
   app.use(express.static('public'));
   port = process.env.PORT || 5000;
+
+  app.use((req, res, next) => {
+    if (!req.secure) {
+      return res.redirect('https://' + req.header('host') + req.url);
+    }
+    next();
+  });
 }
 
 var connectionConfig = {


### PR DESCRIPTION
Some people mention that Windows Azure Websites require checking some weird header to determine if the original request was over SSL:

```ts
const isHttpsRequest = !!req.header('x-arr-ssl');
```

However I'd like to start with just this. Will have to deploy to see if it does the right thing D: Maybe would help to start having a dev instance in addition to the prod one?